### PR TITLE
Move flush after newline

### DIFF
--- a/src/progrock/core.clj
+++ b/src/progrock/core.clj
@@ -102,5 +102,5 @@
    (print bar {}))
   ([bar options]
    (core/print (str "\r" (render bar options)))
-   (flush)
-   (when (:done? bar) (newline))))
+   (when (:done? bar) (newline))
+   (flush)))


### PR DESCRIPTION
In some cases, something printed just after rendering done bar is continuous bacause `(newline)` is not flushed immediately.

e.g. stderr just after rendering done bar

```
100/100   100% [==================================================]  ETA: 00:00error message:
  foo bar
```

This PR fixes this problem by moving `(flush)` after `(newline)`.