### PR TITLE
interval-str needs to display no value when large milliseconds value is passed in

### DIFF
--- a/src/progrock/core.clj
+++ b/src/progrock/core.clj
@@ -42,12 +42,12 @@
   (if (pos? total) (int (* 100 (/ progress total))) 0))
 
 (defn- interval-str [milliseconds]
-  (if (and (some? milliseconds)
-           (> Integer/MAX_VALUE milliseconds))
+  (if (or (nil? milliseconds)
+           (>= milliseconds Integer/MAX_VALUE))
+    "--:--"
     (let [seconds (-> milliseconds (/ 1000) int (mod 60))
           minutes (-> milliseconds (/ 60000) int)]
-      (format "%02d:%02d" minutes seconds))
-    "--:--"))
+      (format "%02d:%02d" minutes seconds))))
 
 (defn elapsed-time [{:keys [creation-time]}]
   (- (System/currentTimeMillis) creation-time))

--- a/src/progrock/core.clj
+++ b/src/progrock/core.clj
@@ -42,11 +42,12 @@
   (if (pos? total) (int (* 100 (/ progress total))) 0))
 
 (defn- interval-str [milliseconds]
-  (if (nil? milliseconds)
-    "--:--"
-    (let [seconds (-> milliseconds (/ 1000) bigint (mod 60))
-          minutes (-> milliseconds (/ 60000) bigint)]
-      (str minutes ":" seconds))))
+  (if (and (some? milliseconds)
+           (> Integer/MAX_VALUE milliseconds))
+    (let [seconds (-> milliseconds (/ 1000) int (mod 60))
+          minutes (-> milliseconds (/ 60000) int)]
+      (format "%02d:%02d" minutes seconds))
+    "--:--"))
 
 (defn elapsed-time [{:keys [creation-time]}]
   (- (System/currentTimeMillis) creation-time))

--- a/src/progrock/core.clj
+++ b/src/progrock/core.clj
@@ -44,9 +44,9 @@
 (defn- interval-str [milliseconds]
   (if (nil? milliseconds)
     "--:--"
-    (let [seconds (mod (int (/ milliseconds 1000)) 60)
-          minutes (int (/ milliseconds 60000))]
-      (format "%02d:%02d" minutes seconds))))
+    (let [seconds (-> milliseconds (/ 1000) bigint (mod 60))
+          minutes (-> milliseconds (/ 60000) bigint)]
+      (str minutes ":" seconds))))
 
 (defn elapsed-time [{:keys [creation-time]}]
   (- (System/currentTimeMillis) creation-time))

--- a/src/progrock/core.clj
+++ b/src/progrock/core.clj
@@ -43,7 +43,7 @@
 
 (defn- interval-str [milliseconds]
   (if (or (nil? milliseconds)
-           (>= milliseconds Integer/MAX_VALUE))
+          (>= milliseconds Integer/MAX_VALUE))
     "--:--"
     (let [seconds (-> milliseconds (/ 1000) int (mod 60))
           minutes (-> milliseconds (/ 60000) int)]


### PR DESCRIPTION
Change the display of minutes and seconds to use str instead of format as well.